### PR TITLE
fixed pong command, added 2 others

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -6,6 +6,21 @@ bot = Bot(command_prefix='>>>')
 
 @bot.command()
 async def ping(ctx):
-    await channel.send("Pong!")
+    await ctx.channel.send("Pong!")
+    
+@bot.command(aliases=['md'])
+async def markdown(ctx):
+    await ctx.channel.send(("**Hey you!** Here is how you can use markdown syntax\n\n"
+                        "\`\`\`py\n"
+                        "print('Woah! Markdown helps me read your code :)')\n"
+                        "\`\`\`\n\n"
+                        "Will *magically* turn into this\n\n"
+                        "```py\n"
+                        "print('Woah! Markdown helps me read your code :)')\n"
+                        "```")
+                      )
+@bot.command()
+async def inlang(ctx, lang, *, code):
+    await ctx.channel.send("```{0}\n{1}\n```".format(lang, code))
 
 bot.run(config['token'])


### PR DESCRIPTION
- Added `inlang` command. `[p]inlang language text`
posts `text` in a `language` codeblock

- Added `markdown` command. `[p]markdown`
aliases: `md`
posts a quick tutorial on how to post python code in a codeblock